### PR TITLE
Fix RectGenerator syntax errors

### DIFF
--- a/Classes/Services/RectGenerator.cs
+++ b/Classes/Services/RectGenerator.cs
@@ -1,15 +1,19 @@
-﻿using SkiaSharp;
+using System.Collections.Generic;
+using System.Linq;
+using SkiaSharp;
 
 namespace AustralianFall.Classes.Services
 {
     internal static class RectGenerator
     {
-        private readonly static Random ran = new();
+        private static readonly Random ran = new();
         private static readonly float Widtho = 1000;
 
-        internal static SKRect GenerateRect(List<SKRect> rects, float height = 100f, float width = 100f, float lowerPt = 700f){
+        internal static SKRect GenerateRect(List<SKRect> rects, float height = 100f, float width = 100f, float lowerPt = 700f)
+        {
             bool overlaps = true;
             SKRect newRect = new SKRect();
+
             while (overlaps)
             {
                 float left = (float)(ran.NextDouble() * (Widtho - width));
@@ -17,7 +21,8 @@ namespace AustralianFall.Classes.Services
                 newRect = new SKRect(left, top, left + width, top + height);
                 overlaps = rects.Any(rect => rect.IntersectsWith(newRect));
             }
+
             return newRect;
-            }
         }
+    }
 }


### PR DESCRIPTION
## Summary
- correct the brace structure in `RectGenerator` to restore proper namespace and class closure
- add the missing using directives and formatting improvements for readability

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5752b955c832bab71bc6092af7c7c